### PR TITLE
Update

### DIFF
--- a/miniprogram/components/itemTabBar/itemTabBar.js
+++ b/miniprogram/components/itemTabBar/itemTabBar.js
@@ -73,6 +73,11 @@ Component({
       //Function is called when the user clicks on the add to Cart button
       //Trigger the event "addToCart" in the parent page which should
       this.triggerEvent('addToCart');
-    }
+    },
+    handleContact: function(e) {
+      console.log("function handleContact")
+      console.log(e.detail.path)
+      console.log(e.detail.query)
+  }
   }
 })

--- a/miniprogram/components/itemTabBar/itemTabBar.wxml
+++ b/miniprogram/components/itemTabBar/itemTabBar.wxml
@@ -4,7 +4,7 @@
   <view class="insidePaddingContainer">
     <view class="iconsContainer">
       <vant-goods-action-icon icon="wap-home-o" text="Home" icon-class="iconCustom" link-type="switchTab" url="../../pages/index/index"></vant-goods-action-icon>
-      <vant-goods-action-icon icon="service-o" text="Help" icon-class="iconCustom"></vant-goods-action-icon>
+      <vant-goods-action-icon icon="service-o" text="Help" icon-class="iconCustom" open-type="contact" bindcontact="handleContact"></vant-goods-action-icon>
       <!-- _numItems is a value that is set by numItems which is passed in from the parent page. Only the parent changes the value-->
       <vant-goods-action-icon icon="cart-o" text="My Cart" icon-class="iconCustom" info="{{_numItems > 0 ? _numItems : null}}"></vant-goods-action-icon>
     </view>

--- a/miniprogram/pages/item/item.js
+++ b/miniprogram/pages/item/item.js
@@ -260,6 +260,10 @@ Page({
     let isFavorited = !pastIsFavorited;
     this.setData({isFavorited});
   },
+  onShareAppMessage: function (shareParams) {
+    console.log("function onShareAppMessage")
+    console.log(shareParams)
+  },
   updateIsFavorited: function(){
     console.log("updateIsFav()");
     //Function called on page close. Gets current isFavorited boolean and updates the user's fav item list

--- a/miniprogram/pages/item/item.wxml
+++ b/miniprogram/pages/item/item.wxml
@@ -1,4 +1,4 @@
-<import src="../itemTabBarTemp/itemTabBarTemp.wxml"></import>
+<import src="../../components/itemTabBar/itemTabBar.wxml"></import>
 <import src="../template/template.wxml"></import>
 
 <CustomNavBar isBack ="{{true}}"></CustomNavBar>
@@ -29,9 +29,10 @@
                 <mp-icon icon="like" size="{{30}}" color="black" type="{{isFavorited ? 'field' : 'outline'}}"></mp-icon>
               </view>
               <view hover-class="mp-icon-hover" hover-stay-time="{{200}}">
-                <mp-icon icon="share" size="{{30}}" color="black"></mp-icon>
+                  <button open-type="share">
+                    <mp-icon icon="share" size="{{30}}" color="black"></mp-icon>
+                  </button>
               </view>
-              
             </view>
           </view>
           <view id="mainRow">


### PR DESCRIPTION
1. Added handleContact to itemTabBar.js as handler for open-type="contact"
2. Added onShareAppMessage to item.js as handler for sharing and open-type="share". Since mp-icon is not native components that supports embeding button component in order to use open-type, it is replaced temporarily with a button wrapper.